### PR TITLE
gafrc options

### DIFF
--- a/cfgreg.c
+++ b/cfgreg.c
@@ -579,7 +579,10 @@ static CfgEntry g_cfg_registry[] =
         "schematic.attrib",
         "promote",
         "true",
-        ""
+        "Set if attribute promotion occurs when you instantiate a component.\n"
+        "Attribute promotion means that any floating (unattached)"
+        " attribute which is inside a symbol gets attached to the newly"
+        " inserted component when it is instantiated."
     },
     {
         "schematic.attrib",

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -578,6 +578,12 @@ static CfgEntry g_cfg_registry[] =
         "true",
         ""
     },
+    {
+        "schematic.attrib",
+        "promote-invisible",
+        "false",
+        ""
+    },
 
     //
     // lepton-netlist:

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -572,6 +572,12 @@ static CfgEntry g_cfg_registry[] =
         "footprint;device;value;model-name",
         ""
     },
+    {
+        "schematic.attrib",
+        "promote",
+        "true",
+        ""
+    },
 
     //
     // lepton-netlist:

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -584,6 +584,12 @@ static CfgEntry g_cfg_registry[] =
         "false",
         ""
     },
+    {
+        "schematic.attrib",
+        "keep-invisible",
+        "true",
+        ""
+    },
 
     //
     // lepton-netlist:

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -590,6 +590,13 @@ static CfgEntry g_cfg_registry[] =
         "true",
         ""
     },
+    // schematic.backup: //
+    {
+        "schematic.backup",
+        "create-files",
+        "true",
+        ""
+    },
 
     //
     // lepton-netlist:

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -530,6 +530,12 @@ static CfgEntry g_cfg_registry[] =
     },
     {
         "schematic",
+        "bus-ripper-symname",
+        "busripper-1.sym",
+        ""
+    },
+    {
+        "schematic",
         "net-consolidate",
         "true",
         "Controls if the net consolidation code is used when schematics are read"

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -565,6 +565,13 @@ static CfgEntry g_cfg_registry[] =
         "Controls if the log window is shown when lepton-schematic is started up"
         " (\"startup\"), or not (\"later\")."
     },
+    // schematic.attrib: //
+    {
+        "schematic.attrib",
+        "always-promote",
+        "footprint;device;value;model-name",
+        ""
+    },
 
     //
     // lepton-netlist:

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -588,7 +588,8 @@ static CfgEntry g_cfg_registry[] =
         "schematic.attrib",
         "promote-invisible",
         "false",
-        ""
+        "Set if invisible floating attributes are promoted when a component"
+        " is instantiated."
     },
     {
         "schematic.attrib",

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -595,7 +595,13 @@ static CfgEntry g_cfg_registry[] =
         "schematic.attrib",
         "keep-invisible",
         "true",
-        ""
+        "If both attribute-promotion and promote-invisible are enabled, then this"
+        " controls if invisible floating attributes are kept around in memory and"
+        " NOT deleted.  Having this enabled will keeps component slotting working."
+        " If attribute-promotion and promote-invisible are enabled and this"
+        " keyword is disabled, then component slotting will NOT work (and maybe"
+        " other functions which depend on hidden attributes, since those attributes"
+        " are deleted from memory)."
     },
     // schematic.backup: //
     {

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -572,7 +572,8 @@ static CfgEntry g_cfg_registry[] =
         "schematic.attrib",
         "always-promote",
         "footprint;device;value;model-name",
-        ""
+        "The list of attributes that are always promoted"
+        " regardless of their visibility."
     },
     {
         "schematic.attrib",

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -608,7 +608,7 @@ static CfgEntry g_cfg_registry[] =
         "schematic.backup",
         "create-files",
         "true",
-        ""
+        "Enable the creation of backup files (name.sch~) when saving a schematic."
     },
 
     //

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -532,7 +532,9 @@ static CfgEntry g_cfg_registry[] =
         "schematic",
         "bus-ripper-symname",
         "busripper-1.sym",
-        ""
+        "The default bus ripper symbol, used when the schematic::bus-ripper-type"
+        " configuration key is set to \"component\". The symbol must exist"
+        " in a component library."
     },
     {
         "schematic",


### PR DESCRIPTION
Add config keys for options previously defined in `system-gafrc`
and deprecated in the following lepton-eda PRs:
- lepton-eda/lepton-eda#539 ("Get rid of the bitmap-directory option, deprecate bus-ripper-symname")
- lepton-eda/lepton-eda#542 ("Deprecate other gafrc options")

```ini
[schematic.attrib]
always-promote=footprint;device;value;model-name
keep-invisible=true
promote=true
promote-invisible=false

[schematic.backup]
create-files=true
```

**NOTE**: the description of the `schematic.attrib::keep-invisible`
was copied from `system-gafrc` verbatim. It needs some clarification:

"If both attribute-promotion and promote-invisible are enabled, then this
controls if invisible floating attributes are kept around in memory and
NOT deleted.  Having this enabled will keeps component slotting working.
If attribute-promotion and promote-invisible are enabled and this
keyword is disabled, then component slotting will NOT work (and maybe
other functions which depend on hidden attributes, since those attributes
are deleted from memory)."


