### PR TITLE
Update GUI when nothing is selected in the tree view

### DIFF
--- a/events.c
+++ b/events.c
@@ -140,6 +140,9 @@ on_btn_tst( GtkButton* btn, gpointer* p )
         return;
 
 
+
+    /*
+
     // 1: remember current ctx->grp->key:
     row_cgk* cgk = cgk_mk( rdata );
     printf( " .. cgk: [ %s : %s : %s ]\n", cgk->ctx_, cgk->grp_, cgk->key_ );
@@ -150,21 +153,24 @@ on_btn_tst( GtkButton* btn, gpointer* p )
 
 
     // TESTING:
+    // row_select_by_ctx_grp_key( dlg, ctx, grp, key );
     row_select_by_cgk( dlg, cgk );
     cgk_rm( cgk );
 
-//    row_select_by_ctx_grp_key( dlg, ctx, grp, key );
+    */
+
+
 
 
     // print current path:
-    /*
+//    /*
     GtkTreeModel* mod = gtk_tree_view_get_model( dlg->tree_v_ );
     gchar* str = gtk_tree_model_get_string_from_iter( mod, &it );
     printf( " .. p: [%s]\n", str );
     GtkTreePath* path = gtk_tree_path_new_from_string( str );
     g_free( str );
     gtk_tree_path_free( path );
-    */
+//    */
     //
 
 
@@ -235,18 +241,33 @@ on_btn_tst( GtkButton* btn, gpointer* p )
 
 // testing:
 //
+// GtkTreeSelection "changed" signal handler
+//
 void
 on_tree_sel_changed( GtkTreeSelection* sel, gpointer p )
 {
     cfg_edit_dlg* dlg = (cfg_edit_dlg*) p;
     g_return_if_fail( dlg != NULL );
 
-//    if ( !dlg )
-//        return;
+
+    GtkTreeModel* mod = NULL;
+    GtkTreeIter it;
+    gboolean res = gtk_tree_selection_get_selected( sel, &mod, &it );
+
+#ifdef DEBUG
+    printf( " .. on_tree_sel_changed(): res: [%d]\n", res );
+#endif
+
+    if ( !res ) // NOTE: tree selection is lost
+    {
+        gui_off( dlg );
+    }
 }
 
 
 
+// GtkTreeView "cursor-changed" signal handler
+//
 void
 on_row_sel( GtkTreeView* tree, gpointer* p )
 {

--- a/gui.c
+++ b/gui.c
@@ -42,6 +42,11 @@ gui_update( cfg_edit_dlg* dlg )
         return;
 
 
+    // eneble showinh chk box, in case it was disabled in gui_off():
+    //
+    gtk_widget_set_sensitive( dlg->btn_showinh_, TRUE );
+
+
     gtk_label_set_text( GTK_LABEL( dlg->lab_ctx_ ), conf_ctx_name( rdata->ctx_ ) );
 
     if ( rdata->rtype_ == RT_GRP || rdata->rtype_ == RT_KEY )
@@ -138,6 +143,32 @@ gui_update( cfg_edit_dlg* dlg )
 //    printf( " >> on_row_sel(): name: [%s], val: [%s]\n", name, val );
 
 } // gui_update()
+
+
+
+// disable GUI controls (except Reload btn), clear labels.
+// call it when tree selection is lost
+//
+void
+gui_off( cfg_edit_dlg* dlg )
+{
+    gtk_widget_set_sensitive( dlg->btn_showinh_, FALSE );
+    // gtk_widget_set_sensitive( dlg->btn_reload_,  FALSE );
+    gtk_widget_set_sensitive( dlg->btn_add_,     FALSE );
+    gtk_widget_set_sensitive( dlg->btn_edit_,    FALSE );
+    gtk_widget_set_sensitive( dlg->btn_toggle_,  FALSE );
+    gtk_widget_set_sensitive( dlg->btn_del_,     FALSE );
+
+    gtk_label_set_text( GTK_LABEL( dlg->lab_ctx_),   NULL );
+    gtk_label_set_text( GTK_LABEL( dlg->lab_fname_), NULL );
+    gtk_label_set_text( GTK_LABEL( dlg->lab_grp_ ),  NULL );
+    gtk_label_set_text( GTK_LABEL( dlg->lab_key_ ),  NULL );
+    gtk_label_set_text( GTK_LABEL( dlg->lab_val_ ),  NULL );
+    gtk_label_set_text( GTK_LABEL( dlg->lab_dflt_ ), NULL );
+
+    gtk_text_buffer_set_text( dlg->txtbuf_desc_, "", -1 );
+
+} // gui_off()
 
 
 

--- a/proto.h
+++ b/proto.h
@@ -144,6 +144,9 @@ void
 gui_update( cfg_edit_dlg* dlg );
 
 void
+gui_off( cfg_edit_dlg* dlg );
+
+void
 gui_mk_labels_line_separ( GtkWidget* parent_box );
 
 void


### PR DESCRIPTION
- disable controls, except the `Reload` button
- clear all labels, except the `working directory` one

Do it in `gui_off()` function, which is called from
the `GtkTreeSelection` "changed" signal handler.

How to reproduce "empty selection" situation:
1. expand some parent node
2. select one of its child nodes
3. click on the parent node's "expander" to collapse it,
so that all its children (including the selected one)
becomes invisible


