### PR TITLE
Support legacy configuration parameters

### DIFF
--- a/cfgreg.c
+++ b/cfgreg.c
@@ -987,7 +987,8 @@ cfgreg_init()
     add_cee( "export", "layout", e_l );
 
     const gchar* gp_l[] = { "auto", "landscape", "portrait", NULL };
-    add_cee( "gschem.printing", "layout", gp_l );
+    add_cee( "gschem.printing",    "layout", gp_l );
+    add_cee( "schematic.printing", "layout", gp_l );
 
     const gchar* s_brr[] = { "non-symmetric", "symmetric", NULL };
     add_cee( "schematic", "bus-ripper-rotation", s_brr );
@@ -1024,6 +1025,7 @@ cfgreg_init()
 
     const gchar* nl_nnp[] = { "net-attribute", "netname-attribute", NULL };
     add_cee( "gnetlist", "net-naming-priority", nl_nnp );
+    add_cee( "netlist",  "net-naming-priority", nl_nnp );
 
 #ifdef DEBUG
 //    const gchar* v = NULL;

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -25,7 +25,8 @@ static CfgEntry g_cfg_registry[] =
         "lepton-conf",
         "editor",
         "gvim",
-        "External text editor for configuration files used by lepton-conf (this program)."
+        "External text editor for configuration files used by lepton-conf (this program).",
+        { NULL, NULL, NULL, NULL }
     },
 
     //
@@ -36,7 +37,14 @@ static CfgEntry g_cfg_registry[] =
         "default-filename",
         "untitled",
         "Default file name for any new schematic files.\n"
-        "It is used to create filenames of the form “untitled_N.sch” where N is a number."
+        "It is used to create filenames of the form “untitled_N.sch” where N is a number.",
+        {
+            "gschem",
+            "default-filename",
+            "untitled",
+            "Default file name for any new schematic files.\n"
+            "It is used to create filenames of the form “untitled_N.sch” where N is a number."
+        }
     },
     // library: //
     {
@@ -45,14 +53,29 @@ static CfgEntry g_cfg_registry[] =
         "*",
         "List of attribute names (semicolon-separated) that are displayed in the component select dialog.\n"
         "An empty list will disable the attribute view.\n"
-        "If the first list element is an asterisk \"*\", all attributes will be displayed in the alphabetical order."
+        "If the first list element is an asterisk \"*\", all attributes will be displayed in the alphabetical order.",
+        {
+            "gschem.library",
+            "component-attributes",
+            "*",
+            "List of attribute names (semicolon-separated) that are displayed in the component select dialog.\n"
+            "An empty list will disable the attribute view.\n"
+            "If the first list element is an asterisk \"*\", all attributes will be displayed in the alphabetical order."
+        }
     },
     {
         "schematic.library",
         "sort",
         "false",
         "If \"true\", the component libraries are sorted alphabetically.\n"
-        "Otherwise they are sorted in the order opposite to what they were added in."
+        "Otherwise they are sorted in the order opposite to what they were added in.",
+        {
+            "gschem.library",
+            "sort",
+            "false",
+            "If \"true\", the component libraries are sorted alphabetically.\n"
+            "Otherwise they are sorted in the order opposite to what they were added in."
+        }
     },
     // printing: //
     {
@@ -61,13 +84,27 @@ static CfgEntry g_cfg_registry[] =
         "auto",
         "When using a paper size, set the orientation of the output.\n"
         "If \"auto\" layout is used, the orientation that best fits the drawing will be used.\n"
-        "Possible values: \"portrait\", \"landscape\", or \"auto\""
+        "Possible values: \"portrait\", \"landscape\", or \"auto\"",
+        {
+            "gschem.printing",
+            "layout",
+            "auto",
+            "When using a paper size, set the orientation of the output.\n"
+            "If \"auto\" layout is used, the orientation that best fits the drawing will be used.\n"
+            "Possible values: \"portrait\", \"landscape\", or \"auto\""
+        }
     },
     {
         "schematic.printing",
         "monochrome",
         "false",
-        "Toggle monochrome (\"true\") or color (\"false\") output."
+        "Toggle monochrome (\"true\") or color (\"false\") output.",
+        {
+            "gschem.printing",
+            "monochrome",
+            "false",
+            "Toggle monochrome (\"true\") or color (\"false\") output."
+        }
     },
     {
         "schematic.printing",
@@ -77,27 +114,40 @@ static CfgEntry g_cfg_registry[] =
         "The default value depends on the current locale.\n"
         "Described in the PWG 5101.1 standard (Printer Working Group\n"
         "\"Media Standardized Names\" (http://www.pwg.org/standards.html#s5101).\n"
-        "Examples: \"iso_a4\", \"iso_a5\", \"na_letter\"."
+        "Examples: \"iso_a4\", \"iso_a5\", \"na_letter\".",
+        {
+            "gschem.printing",
+            "paper",
+            "iso_a4",
+            "Size the output for a particular paper size.\n"
+            "The default value depends on the current locale.\n"
+            "Described in the PWG 5101.1 standard (Printer Working Group\n"
+            "\"Media Standardized Names\" (http://www.pwg.org/standards.html#s5101).\n"
+            "Examples: \"iso_a4\", \"iso_a5\", \"na_letter\"."
+        }
     },
     // gui: //
     {
         "schematic.gui",
         "use-docks",
         "false",
-        "How to display widgets: as dialogs or inside the dock widgets."
+        "How to display widgets: as dialogs or inside the dock widgets.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "use-tabs",
         "true",
-        "Whether to use tabbed GUI: display each schematic in its own tab within GtkNotebook widget."
+        "Whether to use tabbed GUI: display each schematic in its own tab within GtkNotebook widget.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "font",
         "",
         "Sets the name of the font to be used to draw text in schematics. For example:\n"
-        "font=OpenGost Type B TT Regular"
+        "font=OpenGost Type B TT Regular",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -107,57 +157,66 @@ static CfgEntry g_cfg_registry[] =
         " and 'edit text' dialogs instead of the default ones "
         "(set in gschem_toplevel.c: 8, 9, 10, 11, 12, 14, 16, 18, 20, 22, 24, 26)."
         " For example:\n"
-        "text-sizes=2;3;4;5;6;8"
+        "text-sizes=2;3;4;5;6;8",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "max-recent-files",
         "10",
         "Maximum number of recent files to show in 'File->Open Recent' menu.\n"
-        "The default is 10."
+        "The default is 10.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "title-show-path",
         "false",
-        "Whether to show full file path in the main window's title."
+        "Whether to show full file path in the main window's title.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "restore-window-geometry",
         "true",
-        "Whether to restore main window's size and position on startup."
+        "Whether to restore main window's size and position on startup.",
+        { NULL, NULL, NULL, NULL }
     },
 
     {
         "schematic.gui",
         "draw-grips",
         "true",
-        "Controls if the editing grips are drawn when selecting objects."
+        "Controls if the editing grips are drawn when selecting objects.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "toolbars",
         "true",
-        "Controls if the toolbars are visible or not."
+        "Controls if the toolbars are visible or not.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "scrollbars",
         "true",
-        "Controls if the scrollbars are visible or not."
+        "Controls if the scrollbars are visible or not.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "handleboxes",
         "true",
-        "Controls if the handleboxes for the menu and toolbars are visible or not."
+        "Controls if the handleboxes for the menu and toolbars are visible or not.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "zoom-with-pan",
         "true",
-        "Sets the zoom functions to pan the display and then zoom."
+        "Sets the zoom functions to pan the display and then zoom.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -165,7 +224,8 @@ static CfgEntry g_cfg_registry[] =
         "false",
         "Controls if text is drawn properly or if a simplified version (a text"
         " string bounding box) is drawn during mouse pan. Drawing a simple"
-        " box speeds up mousepan a lot for big schematics."
+        " box speeds up mousepan a lot for big schematics.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -173,14 +233,16 @@ static CfgEntry g_cfg_registry[] =
         "true",
         "Controls the behavior of the \"Select Component...\" dialog.\n"
         "Allows to place multiple instances of a component"
-        " without having to press the \"Apply\" button each time."
+        " without having to press the \"Apply\" button each time.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "file-preview",
         "true",
         "Controls if the preview area in the File Open/Save As"
-        " dialog boxes is enabled."
+        " dialog boxes is enabled.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -190,20 +252,23 @@ static CfgEntry g_cfg_registry[] =
         " underlying schematics is allowed or not.\n"
         "If this is enabled, then the user cannot (without using the page manager)"
         " move between hierarchy levels."
-        " Otherwise, the user sees all the hierarchy levels as being flat."
+        " Otherwise, the user sees all the hierarchy levels as being flat.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "third-button-cancel",
         "true",
         "Controls if the third mouse button cancels draw actions"
-        " such as placing of a component or drawing of a primitive."
+        " such as placing of a component or drawing of a primitive.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "warp-cursor",
         "false",
-        "Controls if the cursor is warped (moved) when you zoom in and out."
+        "Controls if the cursor is warped (moved) when you zoom in and out.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -211,53 +276,61 @@ static CfgEntry g_cfg_registry[] =
         "false",
         "Controls if the entire bounding box of a symbol is used when figuring out"
         " which end of the pin is considered the active port.\n"
-        "This option is for backward compatibility with old schematic file format."
+        "This option is for backward compatibility with old schematic file format.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "net-direction-mode",
         "true",
-        "Guess the best continuation direction of an L-shape net when adding a net."
+        "Guess the best continuation direction of an L-shape net when adding a net.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "embed-components",
         "false",
-        "Determines if the newly placed components are embedded in the schematic."
+        "Determines if the newly placed components are embedded in the schematic.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "netconn-rubberband",
         "true",
-        "Maintain net connections when you move a connected component or net."
+        "Maintain net connections when you move a connected component or net.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "magnetic-net-mode",
         "true",
         "Whether to mark a possible connection that is close to the current"
-        " cursor position when drawing a net."
+        " cursor position when drawing a net.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "zoom-gain",
         "20",
         "The percentage size increase/decrease when zooming in/out with the"
-        " mouse wheel. Negative values reverses the direction."
+        " mouse wheel. Negative values reverses the direction.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "mousepan-gain",
         "1",
         "Controls how much the display pans when using mouse. A larger value"
-        " provides greater pan distance when moving the mouse."
+        " provides greater pan distance when moving the mouse.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "keyboardpan-gain",
         "20",
         "Controls how much the display pans when using the keyboard keys."
-        " A larger value provides greater pan distance."
+        " A larger value provides greater pan distance.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -265,19 +338,22 @@ static CfgEntry g_cfg_registry[] =
         "10",
         "Controls how many pixels around an object can still be clicked"
         " as part of that object. A larger value gives greater ease in"
-        " selecting small, or narrow objects."
+        " selecting small, or narrow objects.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "text-size",
         "10",
-        "Sets the default text size."
+        "Sets the default text size.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "snap-size",
         "100",
-        "Sets the default grid spacing."
+        "Sets the default grid spacing.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -286,13 +362,15 @@ static CfgEntry g_cfg_registry[] =
         "Controls the number of scroll pan events required to traverse"
         " the viewed schematic area. Larger numbers mean more scroll steps"
         " are required to pan across the viewed area and giving finer"
-        " control over positioning."
+        " control over positioning.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "dots-grid-dot-size",
         "1",
-        "Controls the size of the grid dots (in pixels) in the dots grid display."
+        "Controls the size of the grid dots (in pixels) in the dots grid display.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -301,7 +379,8 @@ static CfgEntry g_cfg_registry[] =
         "Specifies the minimum number of pixels for the grid to be displayed."
         " Controls the density of the displayed grid (smaller numbers will"
         " cause the grid to be drawn denser). This option is only effective"
-        " when the dots-grid-mode is set to \"fixed\"."
+        " when the dots-grid-mode is set to \"fixed\".",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -309,7 +388,8 @@ static CfgEntry g_cfg_registry[] =
         "3",
         "Specifies the minimum line pitch for the grid to be displayed."
         " Controls the maximum density of the displayed grid before the"
-        " minor, then the major grid lines are switched off."
+        " minor, then the major grid lines are switched off.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -318,14 +398,16 @@ static CfgEntry g_cfg_registry[] =
         "Sets the default action feedback mode for copy, move, and component place"
         " operations. Either \"outline\" or \"boundingbox\".\n"
         "When set to \"boundingbox\", just a box surrounding objects"
-        " is drawn, which is much faster. It may help with slow hardware."
+        " is drawn, which is much faster. It may help with slow hardware.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "text-caps-style",
         "both",
         "Sets the default caps style used for the input of text.\n"
-        "Either \"both\", \"lower\" or \"upper\"."
+        "Either \"both\", \"lower\" or \"upper\".",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -336,7 +418,8 @@ static CfgEntry g_cfg_registry[] =
         "- popup: display the popup menu\n"
         "- action: perform an action on a single object\n"
         "- stroke: draw strokes\n"
-        "- repeat: repeat the last command"
+        "- repeat: repeat the last command",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -344,7 +427,8 @@ static CfgEntry g_cfg_registry[] =
         "popup",
         "Controls what the third mouse button does:\n"
         "- popup: display the popup menu\n"
-        "- mousepan: mouse panning"
+        "- mousepan: mouse panning",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -354,13 +438,15 @@ static CfgEntry g_cfg_registry[] =
         "- classic: zoom in/out,"
         " with Ctrl - horizontal scroll, with Shift - vertical scroll\n"
         "- gtk: vertical scroll,"
-        " with Shift - horizontal scroll, with Ctrl - zoom in/out"
+        " with Shift - horizontal scroll, with Ctrl - zoom in/out",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
         "grid-mode",
         "mesh",
-        "Either \"mesh\", \"dots\" or \"none\"."
+        "Either \"mesh\", \"dots\" or \"none\".",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -370,7 +456,8 @@ static CfgEntry g_cfg_registry[] =
         "In the variable mode, the grid spacing changes"
         " depending on the zoom factor. In the fixed mode, the grid always"
         " represents the same number of units as the snap-spacing. You can"
-        " control the density of the grid using the dots-grid-fixed-threshold option."
+        " control the density of the grid using the dots-grid-fixed-threshold option.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -386,7 +473,8 @@ static CfgEntry g_cfg_registry[] =
         "  - first click selects the net itself\n"
         "  - second click selects all nets directly connected to the selected one\n"
         "- disabled:\n"
-        "  - mouse clicks just selects the clicked net\n"
+        "  - mouse clicks just selects the clicked net\n",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.gui",
@@ -394,7 +482,8 @@ static CfgEntry g_cfg_registry[] =
         "title-B.sym",
         "Symbol (usually, a title block) to be automatically added"
         " when a new page is created. If you do not want to use a "
-        "title block, set this option to an empty string."
+        "title block, set this option to an empty string.",
+        { NULL, NULL, NULL, NULL }
     },
 
     // tabs: //
@@ -402,44 +491,51 @@ static CfgEntry g_cfg_registry[] =
         "schematic.tabs",
         "show-close-button",
         "true",
-        "Whether to show \"close\" button on each tab."
+        "Whether to show \"close\" button on each tab.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.tabs",
         "show-up-button",
         "true",
-        "Whether to show \"hierarchy up\" button on each tab."
+        "Whether to show \"hierarchy up\" button on each tab.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.tabs",
         "show-tooltips",
         "true",
-        "Whether to show tabs tooltips in tabbed GUI."
+        "Whether to show tabs tooltips in tabbed GUI.",
+        { NULL, NULL, NULL, NULL }
     },
     // status-bar: //
     {
         "schematic.status-bar",
         "show-mouse-buttons",
         "false",
-        "Whether to show mouse buttons assignment indicators."
+        "Whether to show mouse buttons assignment indicators.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.status-bar",
         "show-rubber-band",
         "true",
-        "Whether to show net rubber band mode indicator."
+        "Whether to show net rubber band mode indicator.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.status-bar",
         "show-magnetic-net",
         "true",
-        "Whether to show magnetic net mode indicator."
+        "Whether to show magnetic net mode indicator.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.status-bar",
         "status-bold-font",
         "false",
-        "Whether to display the status line with bolder font weight."
+        "Whether to display the status line with bolder font weight.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.status-bar",
@@ -447,20 +543,23 @@ static CfgEntry g_cfg_registry[] =
         "green",
         "Color to use for the status line text when some mode is activated.\n"
         "The string can be either one of a set of standard names "
-        "(taken from the X11 rgb.txt file), or a hex value in the form '#rrggbb'."
+        "(taken from the X11 rgb.txt file), or a hex value in the form '#rrggbb'.",
+        { NULL, NULL, NULL, NULL }
     },
     // undo: //
     {
         "schematic.undo",
         "modify-viewport",
         "false",
-        "Allow undo/redo operations to change pan and zoom."
+        "Allow undo/redo operations to change pan and zoom.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.undo",
         "undo-control",
         "true",
-        "Controls if the undo is enabled or not."
+        "Controls if the undo is enabled or not.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.undo",
@@ -470,13 +569,15 @@ static CfgEntry g_cfg_registry[] =
         "Either \"disk\" or \"memory\".\n"
         "The disk mechanism is nice because you get undo-level number of"
         " backups of the schematic written to disk as backups so you"
-        " should never lose a schematic due to a crash."
+        " should never lose a schematic due to a crash.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.undo",
         "undo-levels",
         "20",
-        "Determines the number of levels of undo."
+        "Determines the number of levels of undo.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.undo",
@@ -484,7 +585,8 @@ static CfgEntry g_cfg_registry[] =
         "false",
         "Controls if pan or zoom commands are saved in the undo list.\n"
         "If this is enabled, then a pan or zoom will be considered"
-        " a command and can be undone."
+        " a command and can be undone.",
+        { NULL, NULL, NULL, NULL }
     },
 
     // log-window: //
@@ -492,7 +594,8 @@ static CfgEntry g_cfg_registry[] =
         "schematic.log-window",
         "font",
         "Monospace 11",
-        "Custom font for the log window (e.g. \"Monospace 10\")."
+        "Custom font for the log window (e.g. \"Monospace 10\").",
+        { NULL, NULL, NULL, NULL }
     },
     // macro-widget: //
     {
@@ -500,7 +603,8 @@ static CfgEntry g_cfg_registry[] =
         "history-length",
         "10",
         "Maximum number of items to keep in the macro-widget "
-        "command history (10 by default)."
+        "command history (10 by default).",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.macro-widget",
@@ -508,27 +612,31 @@ static CfgEntry g_cfg_registry[] =
         "Monospace 11",
         "Font to be used to draw text in the macro-widget command entry.\n"
         "For example:\n"
-        "font=Monospace 12"
+        "font=Monospace 12",
+        { NULL, NULL, NULL, NULL }
     },
     // schematic: //
     {
         "schematic",
         "bus-ripper-size",
         "200",
-        "Sets the size of the auto bus rippers."
+        "Sets the size of the auto bus rippers.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
         "bus-ripper-type",
         "component",
-        "Sets the bus ripper type, either a \"component\" or plain \"net\"."
+        "Sets the bus ripper type, either a \"component\" or plain \"net\".",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
         "bus-ripper-rotation",
         "non-symmetric",
         "Either \"symmetric\" or \"non-symmetric\". This deals with how the"
-        " bus ripper symbol is rotated when it is auto added to a schematic."
+        " bus ripper symbol is rotated when it is auto added to a schematic.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
@@ -536,7 +644,8 @@ static CfgEntry g_cfg_registry[] =
         "busripper-1.sym",
         "The default bus ripper symbol, used when the schematic::bus-ripper-type"
         " configuration key is set to \"component\". The symbol must exist"
-        " in a component library."
+        " in a component library.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
@@ -545,13 +654,15 @@ static CfgEntry g_cfg_registry[] =
         "Controls if the net consolidation code is used when schematics are read"
         " in, written to disk, and when nets are being drawn (does not consolidate"
         " when things are being copied or moved yet). Net consolidation is the"
-        " connection of nets which can be combined into one."
+        " connection of nets which can be combined into one.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
         "logging",
         "true",
-        "Determines if the logging mechanism is enabled."
+        "Determines if the logging mechanism is enabled.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
@@ -560,14 +671,16 @@ static CfgEntry g_cfg_registry[] =
         "Controls how often a backup copy is made, in seconds.\n"
         "The backup copy is made when you make some change to the schematic,"
         " and there were more than \"interval\" seconds from the last autosave.\n"
-        "Autosaving will not be allowed if setting it to zero."
+        "Autosaving will not be allowed if setting it to zero.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic",
         "log-window",
         "later",
         "Controls if the log window is shown when lepton-schematic is started up"
-        " (\"startup\"), or not (\"later\")."
+        " (\"startup\"), or not (\"later\").",
+        { NULL, NULL, NULL, NULL }
     },
     // schematic.attrib: //
     {
@@ -575,7 +688,8 @@ static CfgEntry g_cfg_registry[] =
         "always-promote",
         "footprint;device;value;model-name",
         "The list of attributes that are always promoted"
-        " regardless of their visibility."
+        " regardless of their visibility.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.attrib",
@@ -584,14 +698,16 @@ static CfgEntry g_cfg_registry[] =
         "Set if attribute promotion occurs when you instantiate a component.\n"
         "Attribute promotion means that any floating (unattached)"
         " attribute which is inside a symbol gets attached to the newly"
-        " inserted component when it is instantiated."
+        " inserted component when it is instantiated.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.attrib",
         "promote-invisible",
         "false",
         "Set if invisible floating attributes are promoted when a component"
-        " is instantiated."
+        " is instantiated.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "schematic.attrib",
@@ -603,14 +719,16 @@ static CfgEntry g_cfg_registry[] =
         " If attribute-promotion and promote-invisible are enabled and this"
         " keyword is disabled, then component slotting will NOT work (and maybe"
         " other functions which depend on hidden attributes, since those attributes"
-        " are deleted from memory)."
+        " are deleted from memory).",
+        { NULL, NULL, NULL, NULL }
     },
     // schematic.backup: //
     {
         "schematic.backup",
         "create-files",
         "true",
-        "Enable the creation of backup files (name.sch~) when saving a schematic."
+        "Enable the creation of backup files (name.sch~) when saving a schematic.",
+        { NULL, NULL, NULL, NULL }
     },
 
     //
@@ -621,14 +739,28 @@ static CfgEntry g_cfg_registry[] =
         "default-net-name",
         "unnamed_net",
         "Default name used for nets for which the user has set\n"
-        "no explicit name via the netname= or net= attributes."
+        "no explicit name via the netname= or net= attributes.",
+        {
+            "gnetlist",
+            "default-net-name",
+            "unnamed_net",
+            "Default name used for nets for which the user has set\n"
+            "no explicit name via the netname= or net= attributes."
+        }
     },
     {
         "netlist",
         "default-bus-name",
         "unnamed_bus",
         "Default name used for buses for which the user has set\n"
-        "no explicit name via the netname= or net= attributes."
+        "no explicit name via the netname= or net= attributes.",
+        {
+            "gnetlist",
+            "default-bus-name",
+            "unnamed_bus",
+            "Default name used for buses for which the user has set\n"
+            "no explicit name via the netname= or net= attributes."
+        }
     },
     {
         "netlist",
@@ -636,73 +768,144 @@ static CfgEntry g_cfg_registry[] =
         "net-attribute",
         "Specify which attribute, net (\"net-attribute\") or netname (\"netname-attribute\"),"
         " has priority if a net is found with two names. Any netname"
-        " conflict will be resolved using the chosen attribute."
+        " conflict will be resolved using the chosen attribute.",
+        {
+            "gnetlist",
+            "net-naming-priority",
+            "net-attribute",
+            "Specify which attribute, net (\"net-attribute\") or netname (\"netname-attribute\"),"
+            " has priority if a net is found with two names. Any netname"
+            " conflict will be resolved using the chosen attribute."
+        }
     },
     {
         "netlist.hierarchy",
         "traverse-hierarchy",
         "true",
-        "Turn on/off hierarchy processing."
+        "Turn on/off hierarchy processing.",
+        {
+            "gnetlist.hierarchy",
+            "traverse-hierarchy",
+            "true",
+            "Turn on/off hierarchy processing."
+        }
     },
     // attribute: //
     {
         "netlist.hierarchy",
         "mangle-refdes-attribute",
         "true",
-        "Whether to mangle sub-schematic's 'refdes' attributes."
+        "Whether to mangle sub-schematic's 'refdes' attributes.",
+        {
+            "gnetlist.hierarchy",
+            "mangle-refdes-attribute",
+            "true",
+            "Whether to mangle sub-schematic's 'refdes' attributes."
+        }
     },
     {
         "netlist.hierarchy",
         "refdes-attribute-order",
         "false",
         "While mangling 'refdes' attributes, whether to append (false)\n"
-        "or prepend (true) sub-schematic's ones."
+        "or prepend (true) sub-schematic's ones.",
+        {
+            "gnetlist.hierarchy",
+            "refdes-attribute-order",
+            "false",
+            "While mangling 'refdes' attributes, whether to append (false)\n"
+            "or prepend (true) sub-schematic's ones."
+        }
     },
     {
         "netlist.hierarchy",
         "refdes-attribute-separator",
         "/",
-        "Separator string used to form mangled 'refdes' attribute names."
+        "Separator string used to form mangled 'refdes' attribute names.",
+        {
+            "gnetlist.hierarchy",
+            "refdes-attribute-separator",
+            "/",
+            "Separator string used to form mangled 'refdes' attribute names."
+        }
     },
     // netname: //
     {
         "netlist.hierarchy",
         "mangle-netname-attribute",
         "true",
-        "Whether to mangle sub-schematic's 'netname' attributes."
+        "Whether to mangle sub-schematic's 'netname' attributes.",
+        {
+            "gnetlist.hierarchy",
+            "mangle-netname-attribute",
+            "true",
+            "Whether to mangle sub-schematic's 'netname' attributes."
+        }
     },
     {
         "netlist.hierarchy",
         "netname-attribute-order",
         "false",
         "While mangling 'netname' attributes, whether to append (false)\n"
-        "or prepend (true) sub-schematic's ones."
+        "or prepend (true) sub-schematic's ones.",
+        {
+            "gnetlist.hierarchy",
+            "netname-attribute-order",
+            "false",
+            "While mangling 'netname' attributes, whether to append (false)\n"
+            "or prepend (true) sub-schematic's ones."
+        }
     },
     {
         "netlist.hierarchy",
         "netname-attribute-separator",
         "/",
-        "Separator string used to form mangled 'netname' attribute names."
+        "Separator string used to form mangled 'netname' attribute names.",
+        {
+            "gnetlist.hierarchy",
+            "netname-attribute-separator",
+            "/",
+            "Separator string used to form mangled 'netname' attribute names."
+        }
     },
     // net: //
     {
         "netlist.hierarchy",
         "mangle-net-attribute",
         "true",
-        "Whether to mangle sub-schematic's 'net' attributes."
+        "Whether to mangle sub-schematic's 'net' attributes.",
+        {
+            "gnetlist.hierarchy",
+            "mangle-net-attribute",
+            "true",
+            "Whether to mangle sub-schematic's 'net' attributes."
+        }
     },
     {
         "netlist.hierarchy",
         "net-attribute-order",
         "false",
         "While mangling 'net' attributes, whether to append (false)\n"
-        "or prepend (true) sub-schematic's ones."
+        "or prepend (true) sub-schematic's ones.",
+        {
+            "gnetlist.hierarchy",
+            "net-attribute-order",
+            "false",
+            "While mangling 'net' attributes, whether to append (false)\n"
+            "or prepend (true) sub-schematic's ones."
+        }
     },
     {
         "netlist.hierarchy",
         "net-attribute-separator",
         "/",
-        "Separator string used to form mangled 'net' attribute names."
+        "Separator string used to form mangled 'net' attribute names.",
+        {
+            "gnetlist.hierarchy",
+            "net-attribute-separator",
+            "/",
+            "Separator string used to form mangled 'net' attribute names."
+        }
     },
 
     //
@@ -718,19 +921,22 @@ static CfgEntry g_cfg_registry[] =
         "Set how the drawing is aligned within the page. HALIGN controls the"
         " horizontal alignment, and VALIGN the vertical. Each alignment value"
         " should be in the range 0.0 to 1.0. The \"auto\" alignment is equivalent"
-        " to a value of 0.5;0.5, i.e. centered."
+        " to a value of 0.5;0.5, i.e. centered.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
         "dpi",
         "96",
-        "Set the number of pixels per inch used when generating PNG output."
+        "Set the number of pixels per inch used when generating PNG output.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
         "font",
         "Sans",
-        "Set the font to be used for drawing text."
+        "Set the font to be used for drawing text.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
@@ -738,7 +944,8 @@ static CfgEntry g_cfg_registry[] =
         "auto",
         "Predefined string: \"portrait\", \"landscape\", or \"auto\".\n"
         "When using a paper size, set the orientation of the output. If \"auto\""
-        " layout is used, the orientation that best fits the drawing will be used."
+        " layout is used, the orientation that best fits the drawing will be used.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
@@ -747,13 +954,15 @@ static CfgEntry g_cfg_registry[] =
         "List of four integers in the form TOP;LEFT;BOTTOM;RIGHT.\n"
         "Set the widths of the margins to be used (the minimal distances"
         " from the sheet edges; actual margins may be larger if the sizes"
-        " of the chosen paper do not meet the sizes of the printed schematic)."
+        " of the chosen paper do not meet the sizes of the printed schematic).",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
         "monochrome",
         "false",
-        "Toggle monochrome (true) or color (false) output."
+        "Toggle monochrome (true) or color (false) output.",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
@@ -763,7 +972,8 @@ static CfgEntry g_cfg_registry[] =
         "The default value depends on the current locale.\n"
         "Described in the PWG 5101.1 standard (Printer Working Group\n"
         "\"Media Standardized Names\" (http://www.pwg.org/standards.html#s5101).\n"
-        "Examples: \"iso_a4\", \"iso_a5\", \"na_letter\"."
+        "Examples: \"iso_a4\", \"iso_a5\", \"na_letter\".",
+        { NULL, NULL, NULL, NULL }
     },
     {
         "export",
@@ -771,14 +981,16 @@ static CfgEntry g_cfg_registry[] =
         "",
         "Size the output with specific dimensions. If the size is \"auto\","
         " select the size that best fits the drawing. This overrides the"
-        " [export]::paper key."
+        " [export]::paper key.",
+        { NULL, NULL, NULL, NULL }
     },
 
     {
         NULL,
         NULL,
         NULL,
-        NULL
+        NULL,
+        { NULL, NULL, NULL, NULL }
     }
 };
 

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -11,7 +11,7 @@
 
 
 
-CfgEntryEnum*
+static CfgEntryEnum*
 find_cee( const gchar* grp, const gchar* key );
 
 

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -785,6 +785,43 @@ static CfgEntry g_cfg_registry[] =
 
 
 
+// CfgEntry fields accessor functions:
+//
+static const gchar*
+cfg_entry_get_grp( const CfgEntry* entry )
+{
+    if ( g_cfg_legacy_mode && entry->legacy_.grp_ )
+        return entry->legacy_.grp_;
+    return entry->grp_;
+}
+
+static const gchar*
+cfg_entry_get_key( const CfgEntry* entry )
+{
+    if ( g_cfg_legacy_mode && entry->legacy_.key_ )
+        return entry->legacy_.key_;
+    return entry->key_;
+}
+
+static const gchar*
+cfg_entry_get_dflt_val( const CfgEntry* entry )
+{
+    if ( g_cfg_legacy_mode && entry->legacy_.def_val_ )
+        return entry->legacy_.def_val_;
+    return entry->def_val_;
+}
+
+static const gchar*
+cfg_entry_get_descr( const CfgEntry* entry )
+{
+    if ( g_cfg_legacy_mode && entry->legacy_.desc_ )
+        return entry->legacy_.desc_;
+    return entry->desc_;
+}
+
+
+
+
 // private:
 // find CfgEntry in global cfg registry by group name and key name
 //
@@ -794,10 +831,10 @@ cfgreg_lookup( const gchar* grp, const gchar* key )
     const CfgEntry* entry = g_cfg_registry;
     const CfgEntry* ret   = NULL;
 
-    for ( ; entry->grp_ != NULL; ++entry )
+    for ( ; cfg_entry_get_grp( entry ) != NULL; ++entry )
     {
-        gboolean cond1 = g_strcmp0( entry->grp_, grp ) == 0;
-        gboolean cond2 = g_strcmp0( entry->key_, key ) == 0;
+        gboolean cond1 = g_strcmp0( cfg_entry_get_grp( entry ), grp ) == 0;
+        gboolean cond2 = g_strcmp0( cfg_entry_get_key( entry ), key ) == 0;
 
         if ( cond1 && cond2 )
         {
@@ -822,7 +859,7 @@ cfgreg_lookup_descr( const gchar* grp, const gchar* key )
     const CfgEntry* entry = cfgreg_lookup( grp, key );
 
     if ( entry != NULL )
-        return entry->desc_;
+        return cfg_entry_get_descr( entry );
 
     return NULL;
 }
@@ -835,7 +872,7 @@ cfgreg_lookup_dflt_val( const gchar* grp, const gchar* key )
     const CfgEntry* entry = cfgreg_lookup( grp, key );
 
     if ( entry != NULL )
-        return entry->def_val_;
+        return cfg_entry_get_dflt_val( entry );
 
     return NULL;
 }
@@ -872,11 +909,11 @@ cfgreg_populate_ctx( EdaConfig* ctx )
 {
     const CfgEntry* entry = g_cfg_registry;
 
-    for ( ; entry->grp_ != NULL; ++entry )
+    for ( ; cfg_entry_get_grp( entry ) != NULL; ++entry )
     {
-        const gchar* grp     = entry->grp_;
-        const gchar* key     = entry->key_;
-        const gchar* def_val = entry->def_val_;
+        const gchar* grp     = cfg_entry_get_grp( entry );
+        const gchar* key     = cfg_entry_get_key( entry );
+        const gchar* def_val = cfg_entry_get_dflt_val( entry );
 
         eda_config_set_string( ctx, grp, key, def_val );
     }

--- a/cfgreg.c
+++ b/cfgreg.c
@@ -32,7 +32,7 @@ static CfgEntry g_cfg_registry[] =
     // lepton-schematic:
     //
     {
-        "gschem",
+        "schematic",
         "default-filename",
         "untitled",
         "Default file name for any new schematic files.\n"
@@ -40,7 +40,7 @@ static CfgEntry g_cfg_registry[] =
     },
     // library: //
     {
-        "gschem.library",
+        "schematic.library",
         "component-attributes",
         "*",
         "List of attribute names (semicolon-separated) that are displayed in the component select dialog.\n"
@@ -48,7 +48,7 @@ static CfgEntry g_cfg_registry[] =
         "If the first list element is an asterisk \"*\", all attributes will be displayed in the alphabetical order."
     },
     {
-        "gschem.library",
+        "schematic.library",
         "sort",
         "false",
         "If \"true\", the component libraries are sorted alphabetically.\n"
@@ -56,7 +56,7 @@ static CfgEntry g_cfg_registry[] =
     },
     // printing: //
     {
-        "gschem.printing",
+        "schematic.printing",
         "layout",
         "auto",
         "When using a paper size, set the orientation of the output.\n"
@@ -64,13 +64,13 @@ static CfgEntry g_cfg_registry[] =
         "Possible values: \"portrait\", \"landscape\", or \"auto\""
     },
     {
-        "gschem.printing",
+        "schematic.printing",
         "monochrome",
         "false",
         "Toggle monochrome (\"true\") or color (\"false\") output."
     },
     {
-        "gschem.printing",
+        "schematic.printing",
         "paper",
         "iso_a4",
         "Size the output for a particular paper size.\n"
@@ -617,21 +617,21 @@ static CfgEntry g_cfg_registry[] =
     // lepton-netlist:
     //
     {
-        "gnetlist",
+        "netlist",
         "default-net-name",
         "unnamed_net",
         "Default name used for nets for which the user has set\n"
         "no explicit name via the netname= or net= attributes."
     },
     {
-        "gnetlist",
+        "netlist",
         "default-bus-name",
         "unnamed_bus",
         "Default name used for buses for which the user has set\n"
         "no explicit name via the netname= or net= attributes."
     },
     {
-        "gnetlist",
+        "netlist",
         "net-naming-priority",
         "net-attribute",
         "Specify which attribute, net (\"net-attribute\") or netname (\"netname-attribute\"),"
@@ -639,67 +639,67 @@ static CfgEntry g_cfg_registry[] =
         " conflict will be resolved using the chosen attribute."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "traverse-hierarchy",
         "true",
         "Turn on/off hierarchy processing."
     },
     // attribute: //
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "mangle-refdes-attribute",
         "true",
         "Whether to mangle sub-schematic's 'refdes' attributes."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "refdes-attribute-order",
         "false",
         "While mangling 'refdes' attributes, whether to append (false)\n"
         "or prepend (true) sub-schematic's ones."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "refdes-attribute-separator",
         "/",
         "Separator string used to form mangled 'refdes' attribute names."
     },
     // netname: //
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "mangle-netname-attribute",
         "true",
         "Whether to mangle sub-schematic's 'netname' attributes."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "netname-attribute-order",
         "false",
         "While mangling 'netname' attributes, whether to append (false)\n"
         "or prepend (true) sub-schematic's ones."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "netname-attribute-separator",
         "/",
         "Separator string used to form mangled 'netname' attribute names."
     },
     // net: //
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "mangle-net-attribute",
         "true",
         "Whether to mangle sub-schematic's 'net' attributes."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "net-attribute-order",
         "false",
         "While mangling 'net' attributes, whether to append (false)\n"
         "or prepend (true) sub-schematic's ones."
     },
     {
-        "gnetlist.hierarchy",
+        "netlist.hierarchy",
         "net-attribute-separator",
         "/",
         "Separator string used to form mangled 'net' attribute names."

--- a/proto.h
+++ b/proto.h
@@ -508,6 +508,19 @@ a_delete( cfg_edit_dlg* dlg );
 
 // cfgreg.c:
 //
+
+// struct represents a legacy gEDA configuration key:
+//
+struct _CfgEntryLegacy
+{
+    const gchar* grp_;
+    const gchar* key_;
+    const gchar* def_val_; // default value
+    const gchar* desc_;
+};
+
+typedef struct _CfgEntryLegacy CfgEntryLegacy;
+
 // struct represents a configuration key:
 // NOTE: unique( grp, key )
 //
@@ -517,6 +530,7 @@ struct _CfgEntry
     const gchar* key_;
     const gchar* def_val_; // default value
     const gchar* desc_;
+    const CfgEntryLegacy legacy_;
 };
 
 typedef struct _CfgEntry CfgEntry;


### PR DESCRIPTION
Certain configuration settings have been renamed
in `Lepton EDA` recently.
If `lepton-conf` program is launched with the `-l` flag (i.e. in
"legacy" configuration mode), populate the `DEFAULT`
config context using the old names for those parameters.

This is implemented by extending `CfgEntry` structure:
`legacy_` field of type `CfgEntryLegacy` was added.
`CfgEntryLegacy` structure holds group name, key name,
default value and description for corresponding legacy
parameter.
Auxiliary functions are used to access fields of `CfgEntry`
structure. They check if `lepton-conf` is running in "legacy"
mode, and return appropriate values either from `CfgEntry`
itself or from the corresponding `CfgEntryLegacy` (if any).
